### PR TITLE
Collapse adjacent =??B? words losslessly

### DIFF
--- a/lib/mail/encodings.rb
+++ b/lib/mail/encodings.rb
@@ -300,7 +300,6 @@ module Mail
 
         if encoding == previous_encoding
           line = results.pop + line
-          line.gsub!(/\?\=\=\?.+?\?[QqBb]\?/m, '')
         end
 
         previous_encoding = encoding

--- a/spec/mail/encodings_spec.rb
+++ b/spec/mail/encodings_spec.rb
@@ -154,6 +154,12 @@ describe Mail::Encodings do
       Mail::Encodings.value_decode(string).should == string
     end
 
+    it "should collapse adjacent words" do
+      string = "=?utf-8?B?0L3QvtCy0YvQuSDRgdC+0YLRgNGD0LTQvdC40Log4oCUINC00L7RgNC+0YQ=?=\n =?utf-8?B?0LXQtdCy?="
+      result = "новый сотрудник — дорофеев"
+      Mail::Encodings.value_decode(string).should == result
+    end
+
     if '1.9'.respond_to?(:force_encoding)
       it "should decode 8bit encoded string" do
         string = "=?8bit?Q?ALPH=C3=89E?="


### PR DESCRIPTION
Hey @jeremy I found the commit that we need to fix the subject issue a customer is having but you own the gem. I put the commit on a `2-5-stable-pick-collapse-adjacent-words-losslessly-too` added to `2-5-stable-pick-encoding-for-message-body-too`. Not sure if you want to merge or just add this branch to the main repo.

---

Before this change the code assumed you could concatenate two Base64
strings, which is not true.

This fix relies on non-standard behaviour of our parser: RFC 2047 says
that encoded-words MUST be separated by at least a space, but we happily
parse two unseparated encoded-words.

Fixes: #560
Fixes: #561
Broken-since: 2.5.4 (cb8162165b61c5a65da37341f13f4e40c8d5bcb1)
